### PR TITLE
Summary

### DIFF
--- a/crates/dataguard-cli/src/main.rs
+++ b/crates/dataguard-cli/src/main.rs
@@ -43,9 +43,9 @@ struct Args {
     #[arg(short, long)]
     path: Option<String>,
 
-    /// Enable summary report, return FAILED or PASS per table
+    /// Enable brief report, return FAILED or PASS per table
     #[arg(short, long)]
-    summary: bool,
+    brief: bool,
 
     /// Enable debug mode with detailed error backtraces and stack traces
     #[arg(short, long)]

--- a/crates/dataguard-cli/src/runner.rs
+++ b/crates/dataguard-cli/src/runner.rs
@@ -22,13 +22,13 @@ pub fn run(args: Args) -> Result<bool> {
     // Process validation based on output format
     match args.output {
         OutputFormat::Stdout => {
-            let mut formatter = StdOutFormatter::new(version.to_string(), args.summary);
+            let mut formatter = StdOutFormatter::new(version.to_string(), args.brief);
             formatter.on_start();
             execute_validation(&args, &mut formatter)
         }
         OutputFormat::Json => {
             // JSON output format - placeholder for future implementation
-            let mut formatter = JsonFormatter::new(version.to_string());
+            let mut formatter = JsonFormatter::new(version.to_string(), args.brief);
             formatter.on_start();
             let res = execute_validation(&args, &mut formatter)?;
             let output = formatter
@@ -48,7 +48,7 @@ pub fn watch_run(args: Args) -> Result<bool> {
     // Process validation based on output format
     match args.output {
         OutputFormat::Stdout => {
-            let mut reporter = StdOutFormatter::new(version.to_string(), args.summary);
+            let mut reporter = StdOutFormatter::new(version.to_string(), args.brief);
             reporter.on_start();
             run_watch_loop(&args, &mut reporter)?;
         }
@@ -81,7 +81,7 @@ fn execute_validation<R: Reporter>(args: &Args, reporter: &mut R) -> Result<bool
 
     let passed = res.iter().filter(|r| r.is_passed()).count();
     let failed = res.len() - passed;
-    reporter.on_summary(passed, failed);
+    reporter.on_complete(passed, failed);
 
     Ok(failed == 0)
 }

--- a/crates/dataguard-reports/src/formatters/stdout.rs
+++ b/crates/dataguard-reports/src/formatters/stdout.rs
@@ -5,17 +5,17 @@ use crate::{utils::numbers::format_numbers, Reporter};
 pub struct StdOutFormatter {
     intro: String,
     intro_len: usize,
-    summary: bool,
+    brief: bool,
 }
 
 impl StdOutFormatter {
-    pub fn new(version: String, summary: bool) -> Self {
+    pub fn new(version: String, brief: bool) -> Self {
         let s = format!("DataGuard v{} - Validation Report", version);
         let n = s.len();
         Self {
             intro: s,
             intro_len: n,
-            summary,
+            brief,
         }
     }
     pub fn print_loading_start(&self) {
@@ -42,8 +42,8 @@ impl StdOutFormatter {
             "\n{} ({} rows) - {}",
             result.table_name, rows_formatted, status
         );
-        // If in summary mode, we simply print the above line and stop early
-        if self.summary {
+        // If in brief mode, we simply print the above line and stop early
+        if self.brief {
             return;
         }
 
@@ -71,7 +71,7 @@ impl StdOutFormatter {
         }
     }
 
-    pub fn print_summary(&self, passed: usize, failed: usize) {
+    pub fn print_complete(&self, passed: usize, failed: usize) {
         println!("\n===================================");
         println!("Result: {} failed, {} passed", failed, passed);
     }
@@ -108,8 +108,8 @@ impl Reporter for StdOutFormatter {
         self.print_table_result(result);
     }
 
-    fn on_summary(&self, passed: usize, failed: usize) {
-        self.print_summary(passed, failed);
+    fn on_complete(&self, passed: usize, failed: usize) {
+        self.print_complete(passed, failed);
     }
 
     fn on_waiting(&self) {

--- a/crates/dataguard-reports/src/lib.rs
+++ b/crates/dataguard-reports/src/lib.rs
@@ -10,6 +10,6 @@ pub trait Reporter {
     fn on_table_load(&self, current: usize, total: usize, name: &str);
     fn on_validation_start(&self);
     fn on_table_result(&mut self, result: &ValidationResult);
-    fn on_summary(&self, passed: usize, failed: usize);
+    fn on_complete(&self, passed: usize, failed: usize);
     fn on_waiting(&self);
 }


### PR DESCRIPTION
add a brief mode, this simply return a PASS/FAIL for each table without the column-rules results